### PR TITLE
Build a docker image of Zeebe which includes the Hazelcast exporter

### DIFF
--- a/.ci/podSpecs/distribution.yml
+++ b/.ci/podSpecs/distribution.yml
@@ -1,0 +1,60 @@
+metadata:
+  labels:
+    agent: zeebe-ci-build
+spec:
+  nodeSelector:
+    cloud.google.com/gke-nodepool: agents-n1-standard-32-netssd-preempt
+  tolerations:
+    - key: "agents-n1-standard-32-netssd-preempt"
+      operator: "Exists"
+      effect: "NoSchedule"
+  volumes:
+    - name: shared-data
+      emptyDir: {}
+  containers:
+    - name: maven
+      image: maven:3.6.0-jdk-11
+      command: ["cat"]
+      tty: true
+      env:
+        - name: LIMITS_CPU
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
+        - name: JAVA_TOOL_OPTIONS
+          value: |
+            -XX:+UseContainerSupport
+        - name: DOCKER_HOST
+          value: tcp://localhost:2375
+        - name: ZEEBE_CI_SHARED_DATA
+          value: /home/shared
+      resources:
+        limits:
+          cpu: 2
+          memory: 4Gi
+        requests:
+          cpu: 2
+          memory: 4Gi
+      securityContext:
+        privileged: true
+      volumeMounts:
+        - name: shared-data
+          mountPath: /home/shared
+          mountPropagation: Bidirectional
+    - name: docker
+      image: docker:18.09.4-dind
+      args: ["--storage-driver=overlay2"]
+      securityContext:
+        privileged: true
+      tty: true
+      resources:
+        limits:
+          cpu: 2
+          memory: 4Gi
+        requests:
+          cpu: 2
+          memory: 4Gi
+      volumeMounts:
+        - name: shared-data
+          mountPath: /home/shared
+          mountPropagation: Bidirectional

--- a/.ci/scripts/distribution/prepare.sh
+++ b/.ci/scripts/distribution/prepare.sh
@@ -1,0 +1,4 @@
+#!/bin/sh -eux
+
+apt-get -qq update
+apt-get install --no-install-recommends -qq -y jq libatomic1

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,32 +7,7 @@ pipeline {
       cloud 'zeebe-ci'
       label "zeebe-ci-build_${buildName}"
       defaultContainer 'jnlp'
-      yaml '''\
-apiVersion: v1
-kind: Pod
-metadata:
-  labels:
-    agent: zeebe-ci-build
-spec:
-  nodeSelector:
-    cloud.google.com/gke-nodepool: agents-n1-standard-32-netssd-preempt
-  tolerations:
-    - key: "agents-n1-standard-32-netssd-preempt"
-      operator: "Exists"
-      effect: "NoSchedule"
-  containers:
-    - name: maven
-      image: maven:3.6.0-jdk-11
-      command: ["cat"]
-      tty: true
-      resources:
-        limits:
-          cpu: 1
-          memory: 2Gi
-        requests:
-          cpu: 1
-          memory: 2Gi
-'''
+      yamlFile '.ci/podSpecs/distribution.yml'
     }
   }
 
@@ -44,6 +19,7 @@ spec:
 
   environment {
     NEXUS = credentials("camunda-nexus")
+    DOCKER_HUB = credentials("camunda-dockerhub")
   }
 
   parameters {
@@ -57,8 +33,12 @@ spec:
       steps {
         container('maven') {
           configFileProvider([configFile(fileId: 'maven-nexus-settings-zeebe', variable: 'MAVEN_SETTINGS_XML')]) {
+            sh '.ci/scripts/distribution/prepare.sh'
             sh 'mvn clean install -B -s $MAVEN_SETTINGS_XML -DskipTests'
           }
+        }
+        container('docker') {
+            sh 'docker login --username ${DOCKER_HUB_USR} --password ${DOCKER_HUB_PSW}'
         }
       }
     }
@@ -102,6 +82,7 @@ spec:
         GITHUB_TOKEN = credentials('camunda-jenkins-github')
         RELEASE_VERSION = "${params.RELEASE_VERSION}"
         DEVELOPMENT_VERSION = "${params.DEVELOPMENT_VERSION}"
+        DOCKER_HUB = credentials("camunda-dockerhub")
       }
 
       steps {
@@ -115,7 +96,14 @@ spec:
                 sh 'mkdir ~/.ssh/ && ssh-keyscan github.com >> ~/.ssh/known_hosts'
                 sh 'mvn -B -s $MAVEN_SETTINGS_XML -DskipTests source:jar javadoc:jar release:prepare release:perform -Prelease'
                 sh '.ci/scripts/github-release.sh'
-            }
+             }
+          }
+        }
+        container('maven') {
+          configFileProvider([configFile(fileId: 'maven-nexus-settings-zeebe', variable: 'MAVEN_SETTINGS_XML')]) {
+              sshagent(['camunda-jenkins-github-ssh']) {
+                  sh 'mvn -pl exporter jib:build -Djib.to.auth.username=${DOCKER_HUB_USR} -Djib.to.auth.password=${DOCKER_HUB_PSW}'
+             }
           }
         }
       }

--- a/exporter/pom.xml
+++ b/exporter/pom.xml
@@ -107,9 +107,7 @@
                     </from>
                     <to>
                         <image>docker.io/camunda/zeebe-with-hazelcast-exporter</image>
-                        <tags>
-                            <tag>${version.zeebe}-${project.version}</tag>
-                        </tags>
+                        <tags>latest,${version.zeebe}-${project.version}</tags>
                     </to>
                     <container>
                         <entrypoint>INHERIT</entrypoint>

--- a/exporter/pom.xml
+++ b/exporter/pom.xml
@@ -73,6 +73,7 @@
                     <descriptorRefs>
                         <descriptorRef>jar-with-dependencies</descriptorRef>
                     </descriptorRefs>
+                    <outputDirectory>${project.build.directory}</outputDirectory>
                 </configuration>
                 <executions>
                     <execution>
@@ -82,6 +83,17 @@
                             <goal>single</goal>
                         </goals>
                     </execution>
+                    <execution>
+                        <id>assemble-for-jib</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/jib</outputDirectory>
+                            <finalName>${artifactId}</finalName>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
 
@@ -90,9 +102,26 @@
                 <artifactId>jib-maven-plugin</artifactId>
                 <version>2.5.2</version>
                 <configuration>
+                    <from>
+                        <image>docker.io/camunda/zeebe:${version.zeebe}</image>
+                    </from>
                     <to>
-                        <image>docker.io/camunda/zeebe-hazelcast-exporter</image>
+                        <image>docker.io/camunda/zeebe-with-hazelcast-exporter</image>
+                        <tags>
+                            <tag>${version.zeebe}-${project.version}</tag>
+                        </tags>
                     </to>
+                    <container>
+                        <entrypoint>INHERIT</entrypoint>
+                    </container>
+                    <extraDirectories>
+                        <paths>
+                            <path>
+                                <from>${project.build.directory}/jib</from>
+                                <into>/usr/local/zeebe/exporters</into>
+                            </path>
+                        </paths>
+                    </extraDirectories>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
This is not mean to be used in a production environment. But in some cases, like providing a test library, it can be handy to have a pre-build image instead of building it your own.