### PR TITLE
Handle client exceptions when reading from ring-buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,8 +142,8 @@ zeebe:
           # Hazelcast ringbuffer's capacity
           capacity = 10000 
 
-          # Hazelcast ringbuffer's time-to-live in seconds
-          timeToLiveInSeconds = 3600
+          # Hazelcast ringbuffer's time-to-live in seconds. Don't remove the records until reaching the capacity by setting it to 0.  
+          timeToLiveInSeconds = 0
 
           # record serialization format: [protobuf|json]
           format = "protobuf"

--- a/exporter/src/main/java/io/zeebe/hazelcast/exporter/ExporterConfiguration.java
+++ b/exporter/src/main/java/io/zeebe/hazelcast/exporter/ExporterConfiguration.java
@@ -13,7 +13,7 @@ public class ExporterConfiguration {
   private String name = "zeebe";
 
   private int capacity = -1;
-  private int timeToLiveInSeconds = -1;
+  private int timeToLiveInSeconds = 0;
 
   private String format = "protobuf";
 

--- a/exporter/src/main/java/io/zeebe/hazelcast/exporter/HazelcastExporter.java
+++ b/exporter/src/main/java/io/zeebe/hazelcast/exporter/HazelcastExporter.java
@@ -70,11 +70,11 @@ public class HazelcastExporter implements Exporter {
     ringbuffer = hazelcast.getRingbuffer(config.getName());
     if (ringbuffer == null) {
       throw new IllegalStateException(
-              String.format("Failed to open ringbuffer with name '%s'", config.getName()));
+              String.format("Failed to open ring-buffer with name '%s'", config.getName()));
     }
 
     logger.info(
-            "Export records to ringbuffer with name '{}' [head: {}, tail: {}, size: {}, capacity: {}]",
+            "Export records to ring-buffer with name '{}' [head: {}, tail: {}, size: {}, capacity: {}]",
             ringbuffer.getName(),
             ringbuffer.headSequence(),
             ringbuffer.tailSequence(),
@@ -128,7 +128,12 @@ public class HazelcastExporter implements Exporter {
 
     if (ringbuffer != null) {
       final byte[] transformedRecord = recordTransformer.apply(record);
-      ringbuffer.add(transformedRecord);
+
+      final var sequenceNumber = ringbuffer.add(transformedRecord);
+      logger.trace(
+              "Added a record to the ring-buffer [record-position: {}, ring-buffer sequence-number: {}]",
+              record.getPosition(),
+              sequenceNumber);
     }
 
     controller.updateLastExportedRecordPosition(record.getPosition());


### PR DESCRIPTION
* handle known issues when reading from the ring-buffer and continue with the next possible record
* changing the default exporter configuration to keep records until reaching the capacity

close #70 